### PR TITLE
Add conversation history and reset chat button

### DIFF
--- a/src/global_styles.css
+++ b/src/global_styles.css
@@ -155,6 +155,22 @@ body {
   background-color: #1565c0;
 }
 
+.reset-button {
+  margin-top: 10px;
+  padding: 0.75rem;
+  background-color: #757575;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background-color 0.2s;
+}
+
+.reset-button:hover {
+  background-color: #616161;
+}
+
 select {
   width: 100%;
   padding: 10px;

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,6 +51,7 @@ import { interval, switchMap, takeWhile } from 'rxjs';
             {{ model.name }}
           </option>
         </select>
+        <button (click)="resetChat()" class="reset-button">Reset</button>
         <button (click)="logout()" class="logout-button">Logout</button>
       </div>
       
@@ -83,6 +84,7 @@ export class App {
   models = AVAILABLE_MODELS;
   selectedModel = this.models[0];
   messages: Message[] = [];
+  conversationHistory = '';
   currentMessage = '';
   isLoading = false;
 
@@ -113,6 +115,11 @@ export class App {
   logout() {
     this.authService.logout();
     this.messages = [];
+    this.conversationHistory = '';
+  }
+
+  resetChat() {
+    window.location.reload();
   }
 
   sendMessage() {
@@ -122,11 +129,14 @@ export class App {
       content: this.currentMessage,
       isUser: true
     };
-    
+
     this.messages.push(userMessage);
+    // Add user message to the conversation history
+    this.conversationHistory += (this.conversationHistory ? '\n' : '') + `User: ${this.currentMessage}`;
+
     this.isLoading = true;
 
-    this.chatService.sendMessage(this.currentMessage, this.selectedModel)
+    this.chatService.sendMessage(this.conversationHistory, this.selectedModel)
       .subscribe({
         next: (response) => {
           this.pollPrediction(response.predictionId);
@@ -159,6 +169,8 @@ export class App {
             };
 
             this.messages.push(botMessage);
+            // Add assistant message to the conversation history
+            this.conversationHistory += `\nAssistant: ${response.output.join("")}`;
           } else if (response.status === 'failed') {
             this.displayError();
           }


### PR DESCRIPTION
## Summary
- allow conversation history to be kept between requests
- add reset button to reload the page

## Testing
- `npm run build`
